### PR TITLE
Fields of sub-types should not be added to the current service field list.

### DIFF
--- a/src/main/java/org/jaxws/stub2html/service/Variable2Stub.java
+++ b/src/main/java/org/jaxws/stub2html/service/Variable2Stub.java
@@ -50,14 +50,6 @@ public class Variable2Stub {
 			// System.out.println("Child added as " + child);
 		}
 
-		LinkedList<FieldsOfSubType> fieldsOfSubTypes = getFieldsOfSubTypes(stubType, typeTreeRepository);
-		for (FieldsOfSubType fieldsOfSubType : fieldsOfSubTypes) {
-			for (Field field : fieldsOfSubType.fields) {
-				Stub childStub = convertToStub(createVariableFromField(field), stub, typeTreeRepository);
-				childStub.setSubTypeOfParentStub(fieldsOfSubType.subType);
-			}
-		}
-
 	}
 
 	private static List<Field> getFieldsIncludingAncestorTypes(Class<?> type) {


### PR DESCRIPTION
If they are added, then the list of fields for the current service will contain phantom-fields (fields which do not exist for the current service).