### PR TITLE
Dockerfile - Use docker to run wsdl2html

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM maven:3.6.1-jdk-8 as build
+
+WORKDIR /usr/src
+
+COPY pom.xml ./pom.xml
+COPY src ./src
+
+RUN mvn package
+RUN unzip target/wsdl2html*jarset.zip -d .
+
+FROM maven:3.6.1-jdk-8
+WORKDIR /usr/src
+
+COPY --from=build /usr/src/wsdl2html-4.0.0/ .
+
+ENTRYPOINT [ "./wsdl2html.sh" ]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ cd /path/to/your/dir/wsdl2html*
 
 ```
 
+## Run with docker
+
+```bash
+docker build -t wsdl2html .
+docker run --rm \
+  -v $(pwd)/output:/usr/src/output \
+  wsdl2html http://.../some?wsdl
+```
 
 ## Run it inside your application
 


### PR DESCRIPTION
In some case is hard build de .jar files; using docker image it's more easy to run in continuous integration or any place.

 Use Docker multistage for compile de *.jar and copy in the latest docker stage, set bash script as entrypoint for easy run the script.