### PR TITLE
fixes #44 - changed method to pass all jar files

### DIFF
--- a/src/main/bin/wsdl2html.sh
+++ b/src/main/bin/wsdl2html.sh
@@ -17,4 +17,4 @@ done
 PRGDIR=`dirname "$PRG"`      
   
   
-java -cp $(echo $PRGDIR/jars/*.jar | tr ' ' ':') -Xmx128m org.jaxws.wsdl2html.ui.Wsdl2HtmlMain $*  
+java -cp "$PRGDIR/jars/*" -Xmx128m org.jaxws.wsdl2html.ui.Wsdl2HtmlMain $*  


### PR DESCRIPTION
The list of jars separated by a colon does not work being passed into the cp option of java. Instead, it can just use the asterisk to all the jars in the given folder. After making this change it worked in my setup.